### PR TITLE
Corrigir paginação pela numeração da página.

### DIFF
--- a/app.js
+++ b/app.js
@@ -120,7 +120,7 @@ new Vue({
 
             Vue.set(self.pagination, 'currentPage', page);
 
-            Vue.set(self.cervejaria, 'list', self.cervejarias.paginated[page-1]);
+            Vue.set(self.cervejarias, 'list', self.cervejarias.paginated[page-1]);
         },
 
         next: function(ev)


### PR DESCRIPTION
A paginação pela numeração da página não estava funcionando corretamente pois os dados estavam sendo enviados ao array errado. "cervejaria" ao invés de "cervejarias".
