### PR TITLE
Limite de números na paginação

### DIFF
--- a/app.js
+++ b/app.js
@@ -43,7 +43,8 @@ new Vue({
             currentPage: 1,
             totalPages: 0,
             totalItems: 0,
-            pageNumbers: []
+            pageNumbers: [],
+            visibleNumbers: 3
         },
         interaction: {
             visibleColumns: ['name', 'last_mod'],

--- a/index.html
+++ b/index.html
@@ -212,7 +212,8 @@
                         </li>
                         <li
                             v-for="pageNumber in pagination.pageNumbers"
-                            v-bind:class="{ active:pageNumber == pagination.currentPage }">
+                            v-bind:class="{ active:pageNumber == pagination.currentPage }"
+                            v-if="Math.abs(pageNumber - pagination.currentPage) <= pagination.visibleNumbers">
                             <a href="#" v-on:click="page($event, pageNumber)">{{ pageNumber }}</a>
                         </li>
                         <li v-bind:class="{ disabled:pagination.currentPage == pagination.totalPages }">


### PR DESCRIPTION
Incluir opção de definir a quantidade máxima de números exibidos na paginação antes e depois do currentPage. Basta definir quantidade preferida em visibleNumbers.
